### PR TITLE
Add test ensuring Update-Env not called when command exists

### DIFF
--- a/tests/windows/powershell/Install-OrUpdateApp.Tests.ps1
+++ b/tests/windows/powershell/Install-OrUpdateApp.Tests.ps1
@@ -70,5 +70,11 @@ Describe 'Install-OrUpdateApp' {
             Install-OrUpdateApp -AppId 'Test.App'
             Assert-MockCalled Get-WinGetPackage -Times 1
         }
+
+        It 'skips Update-Env if command exists in PATH' {
+            Mock Get-Command { [pscustomobject]@{ Name = 'testcmd' } }
+            Install-OrUpdateApp -AppId 'Test.App' -UpdateEnv -Command 'testcmd' -AdditionalEnvPath 'C:\TestPath'
+            Assert-MockCalled Update-Env -Times 0
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add coverage for Install-OrUpdateApp when Get-Command finds an existing command, ensuring Update-Env isn't triggered

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/windows/powershell/Install-OrUpdateApp.Tests.ps1"` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899cddea4a8832888aba07c535e75e5