### PR TITLE
Cleanup and general improvements

### DIFF
--- a/home/.chezmoidata/env.yaml
+++ b/home/.chezmoidata/env.yaml
@@ -1,8 +1,0 @@
-# Possible actions [set, extend]
-env:
-  windows: 
-    - var: PATH
-      action: extend
-      value: C:\Program Files (x86)\GnuWin32\bin
-      
-  linux:

--- a/home/dot_config/fzf/dot_fzfrc
+++ b/home/dot_config/fzf/dot_fzfrc
@@ -17,7 +17,7 @@
 
 --info="inline-right"
 --pointer="=>"
---prompt="Files > "
+--prompt="Files❯ "
 
 --color="border:#aaaaaa,label:#cccccc,query:#d9d9d9"
 --color="preview-border:#9999cc,preview-label:#ccccff"

--- a/home/dot_profile/PSReadLine_profile.ps1
+++ b/home/dot_profile/PSReadLine_profile.ps1
@@ -21,7 +21,7 @@ Set-PSReadLineKeyHandler -Key Ctrl+Spacebar -Function MenuComplete
 Set-PSReadLineKeyHandler -Key Ctrl+RightArrow -Function ForwardWord 
 
 # Capitalize, uppercase, and lowercase words
-Set-PSReadLineKeyHandler -Key Alt+c -Function CapitalizeWord
+Set-PSReadLineKeyHandler -Key Ctrl+Alt+c -Function CapitalizeWord
 Set-PSReadLineKeyHandler -Key Alt+u -Function UpcaseWord
 Set-PSReadLineKeyHandler -Key Alt+l -Function DowncaseWord
 
@@ -130,7 +130,7 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
     [Microsoft.PowerShell.PSConsoleReadLine]::Insert($quote)
 }
 
-Set-PSReadLineKeyHandler -Key '(','{','[' `
+Set-PSReadLineKeyHandler -Key '(', '{', '[' `
                          -BriefDescription InsertPairedBraces `
                          -LongDescription "Insert matching braces" `
                          -ScriptBlock {
@@ -219,7 +219,7 @@ Set-PSReadLineKeyHandler -Key Backspace `
     }
 }
 
-# Each time you press Alt+', this key handler will change the token
+# Each time you press Alt+' , this key handler will change the token
 # under or before the cursor.  It will cycle through single quotes, double quotes, or
 # no quotes each time it is invoked.
 Set-PSReadLineKeyHandler -Key "Alt+'" `

--- a/home/dot_profile/_env-variables_profile.ps1.tmpl
+++ b/home/dot_profile/_env-variables_profile.ps1.tmpl
@@ -1,13 +1,5 @@
-# Add Environment Variables
-{{- range .env.windows }}
-{{- if eq .action "set" }}
-$env:{{ .var }} = {{ .value | squote }}
-{{ else if eq .action "extend" }} 
-if ($env:{{ .var }} -notlike "*{{ .value }}*") {
-    $env:{{ .var }} = "$env:{{ .var }};{{ .value }}"
-}
-{{ end -}}
-{{ end -}}
+# Add GnuWin32 to the PATH for Windows
+$env:PATH = "$env:PATH;$env:ProgramFiles(x86)\GnuWin32\bin"
 
 # Initialize the ripgrep config env variable
 $env:RIPGREP_CONFIG_PATH = Join-Path $HOME ".config\.rgrc"
@@ -15,4 +7,3 @@ $env:RIPGREP_CONFIG_PATH = Join-Path $HOME ".config\.rgrc"
 # Initialize the fzf config env variables
 $env:FZF_DEFAULT_OPTS_FILE = Join-Path $HOME ".config\fzf\.fzfrc"
 $env:FZF_DEFAULT_COMMAND = Get-Content -Path (Join-Path $HOME ".config\fzf\.fzfdc")
-$env:_PSFZF_FZF_DEFAULT_OPTS = Get-Content -Path (Join-Path $HOME ".config\fzf\.psfzfrc") 

--- a/home/dot_profile/_env-variables_profile.ps1.tmpl
+++ b/home/dot_profile/_env-variables_profile.ps1.tmpl
@@ -7,3 +7,4 @@ $env:RIPGREP_CONFIG_PATH = Join-Path $HOME ".config\.rgrc"
 # Initialize the fzf config env variables
 $env:FZF_DEFAULT_OPTS_FILE = Join-Path $HOME ".config\fzf\.fzfrc"
 $env:FZF_DEFAULT_COMMAND = Get-Content -Path (Join-Path $HOME ".config\fzf\.fzfdc")
+$env:_PSFZF_FZF_DEFAULT_OPTS = Get-Content -Path (Join-Path $HOME ".config\fzf\.psfzfrc")

--- a/home/readonly_AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json.tmpl
+++ b/home/readonly_AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json.tmpl
@@ -19,7 +19,7 @@
         "split": "auto",
         "splitMode": "duplicate"
       },
-      "keys": "ctrl+t"
+      "keys": "ctrl+alt+t"
     },
     {
       "command": "find",

--- a/home/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/home/readonly_Documents/PowerShell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -1,11 +1,11 @@
 # Pofiles hashes
-{{- range (glob  (joinPath .chezmoi.sourceDir "dot_profile/*.*")) }}
+{{- range (glob  (joinPath .chezmoi.sourceDir "dot_profile/*.ps1*")) }}
 # {{ include . | sha256sum -}}
 {{ end }}
 
 # Import installed modules
 {{- range .packages.windows.modules }}
-Import-Module -Name {{ . | squote }}
+Import-Module -Name {{ . | squote -}}
 {{ end }}
 # Import Custom Modules
 Import-Module -Name 'Write-Pretty' -Force
@@ -13,6 +13,6 @@ Import-Module -Name 'Write-Pretty' -Force
 # Import all profile files
 {{- $base := print .chezmoi.sourceDir "/dot_profile/" }}
 {{- $target := print .chezmoi.config.destDir "/.profile/" }}
-{{- range (glob  (joinPath .chezmoi.sourceDir "dot_profile/*.*")) }}
+{{- range (glob  (joinPath .chezmoi.sourceDir "dot_profile/*.ps1*")) }}
 . {{ replace $base $target . | replace ".tmpl" "" | squote -}}
 {{ end }}

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -10,11 +10,12 @@ Vagrant.configure("2") do |config|
 
     windows.vm.synced_folder "..", "/Users/vagrant/.local/share/chezmoi", type: "virtualbox"
 
-    windows.vm.provider "virtualbox" do |vb|
-      vb.memory = 8192
-      vb.cpus = 4
+    windows.vm.provider "virtualbox" do |v|
+      v.memory = 8192
+      v.cpus = 4
 
-      vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+      v.customize ["modifyvm", :id, "--vram", "128"]
+      v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
     end
   end
 
@@ -24,11 +25,11 @@ Vagrant.configure("2") do |config|
   
     linux.vm.synced_folder "..", "/home/vagrant/.local/share/chezmoi", type: "virtualbox"
         
-    linux.vm.provider "virtualbox" do |vb|
-      vb.memory = 8192         
-      vb.cpus = 4              
+    linux.vm.provider "virtualbox" do |v|
+      v.memory = 8192         
+      v.cpus = 4              
   
-      vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+      v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
     end
   end
 end


### PR DESCRIPTION
This pull request makes several improvements and refinements to Windows and Linux environment setup, shell configuration, and virtualization settings. The changes focus on simplifying environment variable management, enhancing usability in shell tools, and optimizing virtual machine configurations.

**Environment variable and profile management:**

* Simplified Windows environment variable setup by removing the `env.yaml` abstraction and directly appending GnuWin32 to the `PATH` in `_env-variables_profile.ps1.tmpl`, making the configuration more straightforward. [[1]](diffhunk://#diff-ea342e61fc761be586ac1c69b1359d0388e9d3b6a6cfd883e76e58da042a36f4L1-L8) [[2]](diffhunk://#diff-3ed51656edef79425093cb2482595c60205b143f4c86b8472171565b1a3c92fdL1-L18)
* Updated PowerShell profile scripts to only include `.ps1` files and improved module import syntax for consistency and reliability.

**Shell usability improvements:**

* Changed the key binding for `CapitalizeWord` in `PSReadLine_profile.ps1` from `Alt+c` to `Ctrl+Alt+c` to avoid conflicts and improve ergonomics.
* Enhanced the `fzf` prompt in `.fzfrc` to use a Unicode character for better visual distinction.

**Virtual machine configuration:**

* Refactored Vagrantfile provider blocks for both Windows and Linux to use a consistent variable name and added a VRAM setting for Windows VMs, improving resource allocation and maintainability. [[1]](diffhunk://#diff-225f3d44285006fdfb0e6a444342ca7f84f2b8f366ae15fa4360265b535be386L13-R18) [[2]](diffhunk://#diff-225f3d44285006fdfb0e6a444342ca7f84f2b8f366ae15fa4360265b535be386L27-R32)
* Changed the Windows Terminal split key binding from `ctrl+t` to `ctrl+alt+t` in `settings.json.tmpl` to prevent conflicts with common shortcuts.